### PR TITLE
added `A32` and `A64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- added `A32` and `A64` types
+
 ## [v0.3.4] - 2020-07-31
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,14 @@ pub struct A8;
 #[repr(align(16))]
 pub struct A16;
 
+/// 32-byte alignment
+#[repr(align(32))]
+pub struct A32;
+
+/// 64-byte alignment
+#[repr(align(64))]
+pub struct A64;
+
 /// A newtype with alignment of at least `A` bytes
 #[repr(C)]
 pub struct Aligned<A, T>

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -4,3 +4,5 @@ impl Alignment for super::A2 {}
 impl Alignment for super::A4 {}
 impl Alignment for super::A8 {}
 impl Alignment for super::A16 {}
+impl Alignment for super::A32 {}
+impl Alignment for super::A64 {}


### PR DESCRIPTION
I'm unsure if there's a better way to offer larger alignement to the user, but until then here's `A32` and `A64`