### PR TITLE
Add some Borrow/BorrowMut trait impls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ where
 
 impl<A, T> Borrow<T> for Aligned<A, T>
 where
-    A: sealed::Alignment
+    A: sealed::Alignment,
 {
     fn borrow(&self) -> &T {
         &self.value
@@ -156,7 +156,7 @@ where
 
 impl<A, T> BorrowMut<T> for Aligned<A, T>
 where
-    A: sealed::Alignment
+    A: sealed::Alignment,
 {
     fn borrow_mut(&mut self) -> &mut T {
         &mut self.value

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,24 @@ where
     }
 }
 
+impl<A, T> Borrow<T> for Aligned<A, T>
+where
+    A: sealed::Alignment
+{
+    fn borrow(&self) -> &T {
+        &self.value
+    }
+}
+
+impl<A, T> BorrowMut<T> for Aligned<A, T>
+where
+    A: sealed::Alignment
+{
+    fn borrow_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+}
+
 impl<A, T> Borrow<[<Aligned<A, T> as AsSlice>::Element]> for Aligned<A, T>
 where
     A: sealed::Alignment,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 #![cfg_attr(not(test), no_std)]
 
 use core::{
+    borrow::{Borrow, BorrowMut},
     cmp::Ordering,
     fmt::{Debug, Display},
     hash::{Hash, Hasher},
@@ -141,6 +142,26 @@ where
 {
     fn as_mut_slice(&mut self) -> &mut [T::Element] {
         T::as_mut_slice(&mut **self)
+    }
+}
+
+impl<A, T> Borrow<[<Aligned<A, T> as AsSlice>::Element]> for Aligned<A, T>
+where
+    A: sealed::Alignment,
+    Aligned<A, T>: AsSlice,
+{
+    fn borrow(&self) -> &[<Aligned<A, T> as AsSlice>::Element] {
+        self.as_slice()
+    }
+}
+
+impl<A, T> BorrowMut<[<Aligned<A, T> as AsSlice>::Element]> for Aligned<A, T>
+where
+    A: sealed::Alignment,
+    Aligned<A, T>: AsMutSlice,
+{
+    fn borrow_mut(&mut self) -> &mut [<Aligned<A, T> as AsSlice>::Element] {
+        self.as_mut_slice()
     }
 }
 


### PR DESCRIPTION
Hi! I've found myself in the position of needing an `Aligned<[u8; _]>` that could be fed into something that has a `BorrowMut<[u8]>` bound, and realized there are no passthrough impls for Borrow, so, this PR just adds those