### PR TITLE
Add Alignment::new constructor function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,20 @@ where
     }
 }
 
+impl<A, T> Aligned<A, T>
+where
+    A: Alignment,
+{
+    /// Changes the alignment of value to be at least A bytes
+    pub const fn new(value: T) -> Self {
+        Aligned {
+            _alignment: [],
+            value,
+        }
+    }
+}
+
+
 impl<A, T> Aligned<A, [T]>
 where
     A: Alignment,
@@ -523,6 +537,16 @@ fn sanity() {
     let x: Aligned<A2, _> = Aligned([0u8; 3]);
     let y: &Aligned<A2, [u8]> = &x;
     let _: &[u8] = y;
+}
+
+#[test]
+fn test_type_alias_new() {
+    type CacheLineAligned<T> = Aligned<A64, T>;
+
+    let aligned: Aligned<A64, _> = Aligned([0u8; 3]);
+    let aligned_new = CacheLineAligned::new([0u8; 3]);
+
+    assert_eq!(aligned, aligned_new);
 }
 
 #[test]


### PR DESCRIPTION
Currently the only way to construct Aligned value is using `aligned::Aligned` function which returns instance of `Aligned` struct. This does not work well with type aliases. For example, consider this type alias:

```
/// Aligns value at cache line boundary (assuming 64 byte cache line size)
type CacheLineAligned<T> = Aligned<A64, T>;
```

User still has to use `aligned::Aligned` function to create value which breaks abstraction provided by type alias:

```
let cache_aligned_value: CacheLineAligned<u32> = aligned::Aligned(42);
```

In this commit I am implementing a conventional `new` constructor for `struct Aligned` which works with type aliases:

```
let cache_aligned_value = CacheLineAligned::new(42_u32);
```