### PR TITLE
Remove `bors.toml`, no longer used

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,0 @@
-status = [
-  "continuous-integration/travis-ci/push",
-]


### PR DESCRIPTION
It is harmless, but also useless to crate users.